### PR TITLE
Update models.py

### DIFF
--- a/gsum/models.py
+++ b/gsum/models.py
@@ -1197,7 +1197,7 @@ class ConjugateStudentProcess(BaseConjugateProcess):
             kernel = self.kernel_
         kernel = kernel.clone_with_theta(theta)
         if eval_gradient:
-            R, dR = kernel(X, eval_gradient)
+            R, dR = kernel(X, eval_gradient=eval_gradient)
         else:
             R, dR = kernel(X), None
 


### PR DESCRIPTION
Changes treatment of eval_gradient in call of function kernel. Here, eval_gradient used to be treated as a positional argument, which passed its value to y and led to type errors. Now eval_gradient is a keyword argument, which allows the program to run without errors since y's value correctly defaults to None.